### PR TITLE
Fix glyphicons covering links

### DIFF
--- a/htdoc/css/cs1520.css
+++ b/htdoc/css/cs1520.css
@@ -138,6 +138,10 @@ h1, h3 {
   padding-bottom: 150px;
 }
 
+.block.b-ten {
+  clear: both;
+}
+
 @media(min-width:767px) {
   .navbar {
     padding: 20px 0;


### PR DESCRIPTION
The glyphicon stars were covering any links underneath them, so users couldn't click on the links.