### PR TITLE
Fixing peer tutoring website link

### DIFF
--- a/htdoc/cs1520.php
+++ b/htdoc/cs1520.php
@@ -794,7 +794,7 @@
                 <a href="http://www.stackoverflow.com">StackOverflow</a>
               </li>
               <li class="b-ten">
-                <a href="http://www.cs.pitt.edu/undergrad/crc">CS Peer Tutoring Schedule</a>
+                <a href="http://www.cs.pitt.edu/undergrads/crc">CS Peer Tutoring Schedule</a>
               </li>
               <li class="b-ten">
                 <a href="http://www.provost.pitt.edu/information-on/calendar.html">Academic Calendar</a>


### PR DESCRIPTION
I noticed that the Peer Tutoring Link was not correct. You forgot the 's' on the end of undergrad in the URL. Simple mistake, took a second to fix it.