### PR TITLE
Fix 404 on lecture slides, ensure download on 'get' links

### DIFF
--- a/htdoc/cs1520.php
+++ b/htdoc/cs1520.php
@@ -699,13 +699,13 @@
             <p class="uc red-txt bold">Lecture Slides</p>
             <ul>
               <li>
-                <a href="/deliverables/slides/BowytzLect1.pdf">Lecture 1 (follow)</a> | <a href="/deliverables/slides/BowytzLect1.zip">Lecture 1 (get)</a>
+                <a href="/deliverables/slides/BowytzLect1.pdf">Lecture 1 (follow)</a> | <a href="/deliverables/slides/BowytzLect1.pdf" download>Lecture 1 (get)</a>
               </li>
               <li>
-                <a href="/deliverables/slides/BowytzLect2.pdf">Lecture 2 (follow)</a> | <a href="/deliverables/slides/BowytzLect2.zip">Lecture 2 (get)</a>
+                <a href="/deliverables/slides/BowytzLect2.pdf">Lecture 2 (follow)</a> | <a href="/deliverables/slides/BowytzLect2.pdf" download>Lecture 2 (get)</a>
               </li>
               <li>
-                <a href="/deliverables/slides/BowytzLect3.pdf">Lecture 3 (follow)</a> | <a href="/deliverables/slides/BowytzLect3.zip">Lecture 3 (get)</a>
+                <a href="/deliverables/slides/BowytzLect3.pdf">Lecture 3 (follow)</a> | <a href="/deliverables/slides/BowytzLect3.pdf" download>Lecture 3 (get)</a>
               </li>
             </ul>
           </div>


### PR DESCRIPTION
The lecture slide ZIP file links were broken. Since each lecture is comprised of a single file, it doesn't seem like having each one in a zip file makes a ton of sense (they're small files). I fixed the links and added an HTML5 `download` attribute to ensure the files are downloaded, not followed.